### PR TITLE
feat: Add note about demultiplexing staggered SWATH data

### DIFF
--- a/docs/openswath.rst
+++ b/docs/openswath.rst
@@ -54,6 +54,8 @@ The input file ``in`` is generally a single ``mzML``, ``mzXML`` or ``sqMass`` fi
 (converted from a raw vendor file format using `ProteoWizard
 <http://proteowizard.sourceforge.net/>`_).
 
+.. note:: If your data has been acquired using a staggered SWATH acquisition scheme, you will need to add a filter in msconvert to **demultiplex** the data with optimization set to **Overlap Only**. 
+
 Spectral library
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The recent changes in the `openswath.rst` file include adding a note about demultiplexing staggered SWATH data using the `msconvert` filter with optimization set to "Overlap Only". This information is important for users who have acquired data using a staggered SWATH acquisition scheme.