### PR TITLE
docs: update mobi-dik.rst references and add notes for OpenSWATH feat…

### DIFF
--- a/docs/mobi-dik.rst
+++ b/docs/mobi-dik.rst
@@ -80,6 +80,6 @@ References
 
 .. [1] Röst HL, Rosenberger G, Navarro P, Gillet L, Miladinović SM, Schubert OT, Wolski W, Collins BC, Malmström J, Malmström L, Aebersold R. OpenSWATH enables automated, targeted analysis of data-independent acquisition MS data. Nat Biotechnol. 2014 Mar 10;32(3):219-23. doi: 10.1038/nbt.2841. PMID: 24727770
 .. [2] see https://github.com/Roestlab/dia-pasef/
-.. [3] Florian Meier, Andreas-David Brunner, Max Frank, Annie Ha, Eugenia Voytik, Stephanie Kaspar-Schoenefeld, Markus Lubeck, Oliver Raether, Ruedi Aebersold, Ben C. Collins, Hannes L. Röst, Matthias Mann. Parallel accumulation – serial fragmentation combined with data-independent acquisition (diaPASEF): Bottom-up proteomics with near optimal ion usage doi: https://doi.org/10.1101/656207
+.. [3] Florian Meier, Andreas-David Brunner, Max Frank, Annie Ha, Eugenia Voytik, Stephanie Kaspar-Schoenefeld, Markus Lubeck, Oliver Raether, Ruedi Aebersold, Ben C. Collins, Hannes L. Röst, Matthias Mann. diaPASEF: parallel accumulation–serial fragmentation combined with data-independent acquisition. Nature Methods volume 17, pages 1229–1236 (2020). doi: https://www.nature.com/articles/s41592-020-00998-0
 
 

--- a/index.rst
+++ b/index.rst
@@ -9,6 +9,14 @@ News
 
 .. note::
 
+   *2020-05-09:* With OpenMS 3.4.0, OpenSWATH supports automated spectrum addition at RT feature peak apex, peak picking extracted ion mobilograms, and ion mobility scoring for identifying transitions for IPF.
+
+.. note::
+
+   *2020-02-24:* With OpenMS 2.4.0, OpenSWATH supports ion mobility extraction and scoring (diaPASEF data), supports PRM data, supports metabolite assay library generation (via SIRIUS), extraction and scoring.
+
+.. note::
+
    *2018-11-07:* The Docker image now includes OpenMS 2.4.0 and PyProphet 2.0.1.
 
 .. note::
@@ -84,7 +92,7 @@ The OpenSWATH Workflow
 
 .. toctree::
    :maxdepth: 3
-   :caption: Mobi-DIK 
+   :caption: Mobi-DIK (diaPASEF)
    
    docs/mobi-dik
    docs/dataconversion


### PR DESCRIPTION
This pull request updates the documentation to reflect recent improvements in OpenSWATH and clarifies references related to diaPASEF and ion mobility support. The most important changes are grouped below:

**Documentation Updates for New Features:**

* Added notes about new OpenSWATH features in OpenMS 3.4.0 and 2.4.0, including spectrum addition at RT feature peak apex, peak picking for extracted ion mobilograms, ion mobility scoring for IPF, ion mobility extraction and scoring for diaPASEF data, PRM data support, and metabolite assay library generation via SIRIUS.

**Reference and Naming Clarifications:**

* Updated the caption in the documentation navigation to "Mobi-DIK (diaPASEF)" for clearer identification of the workflow's support for diaPASEF.
* Revised the reference for diaPASEF to cite the final published Nature Methods paper instead of the previous preprint, ensuring proper attribution and up-to-date information.…ures