### PR TITLE
docs: add Read the Docs configuration and requirements for Sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+sphinx:
+  configuration: conf.py
+python:
+  install:
+    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=5.0.0
+sphinx-rtd-theme>=1.0.0


### PR DESCRIPTION
This pull request introduces a new configuration file for Read the Docs to enable automated documentation builds using Sphinx and Python 3.10.

Documentation build configuration:

* Added a `.readthedocs.yml` file to specify build environment, Python version, Sphinx configuration, and requirements installation for Read the Docs integration.